### PR TITLE
デプロイ後のエラー修正２

### DIFF
--- a/app/views/timers/today.html.erb
+++ b/app/views/timers/today.html.erb
@@ -3,7 +3,7 @@
 <%= link_to '明日', tomorrow_path %>
 
 <% @times.each do |time| %>
-<% if Date.today == time.time %>
+  <% if Date.today == time.time %>
     <ul>
       <li>タスク</li>
       <li><%= time.time %></li>


### PR DESCRIPTION
# What
デプロイ後に今日の日付の一覧が表示されない
## Why
デプロイ後に今日の日付の一覧のみが表示されないためそれを表示する様に修正
### 仮説１プログラミングの値が取得されていない
他の項目は表示できており、テーブルにも値は保管されている。
### 仮説２ if文のミス
ローカル環境では正常に日付の一覧は表示されているため問題は内容に思える
そのため、HerokuへPushする際に何らかの問題がおき正常にファイルが読み込まれていない、と言う可能性を考え、ほとんど修正していない、ものをサイドHerokuへPushしてみる